### PR TITLE
PR: Add an exclude-pattern flag to exclude directories when scanning for translations

### DIFF
--- a/gettext_helpers/main.py
+++ b/gettext_helpers/main.py
@@ -78,6 +78,16 @@ def main():
         action="store_true",
         help="Create default Crowdin configuration",
     )
+    parser.add_argument(
+        '-ep',
+        '--exclude-pattern',
+        type=str,
+        help=(
+            "Glob pattern to use to exclude directories when running "
+            "the scan command"
+        ),
+        default="test*",
+    )
     sys.stdout.write('\n')
     args = parser.parse_args()
 
@@ -106,9 +116,16 @@ def main():
     # Check path exists
     if args.command == 'scan':
         if args.target_lang is None:
-            scan_path(path, module=args.module)
+            scan_path(
+                path, module=args.module, exclude_pattern=args.exclude_pattern
+            )
         else:
-            scan_path(path, module=args.module, languages=[args.target_lang])
+            scan_path(
+                path,
+                module=args.module,
+                languages=[args.target_lang],
+                exclude_pattern=args.exclude_pattern,
+            )
     elif args.command == 'compile':
         compile_path(path)
     elif args.command == 'translate':

--- a/gettext_helpers/main.py
+++ b/gettext_helpers/main.py
@@ -83,8 +83,7 @@ def main():
         '--exclude-pattern',
         type=str,
         help=(
-            "Glob pattern to use to exclude directories when running "
-            "the scan command"
+            "Glob pattern to exclude directories when running the scan command"
         ),
         default="test*",
     )

--- a/gettext_helpers/utils.py
+++ b/gettext_helpers/utils.py
@@ -59,9 +59,10 @@ def get_files(path, extensions=('.py', '.pyw'), exclude_pattern=None):
     """Get all files in path ending in extension."""
     fpaths = []
     for dirname, dirnames, filenames in os.walk(path):
-        dirnames[:] = [
-            d for d in dirnames if not fnmatch.fnmatch(d, exclude_pattern)
-        ]
+        if exclude_pattern is not None:
+            dirnames[:] = [
+                d for d in dirnames if not fnmatch.fnmatch(d, exclude_pattern)
+            ]
         for filename in filenames:
             if filename.endswith(extensions):
                 fpaths.append(osp.join(dirname, filename))

--- a/gettext_helpers/utils.py
+++ b/gettext_helpers/utils.py
@@ -55,7 +55,7 @@ def _get_locale_path(path):
     return osp.join(path, 'locale')
 
 
-def get_files(path, extensions=('.py', '.pyw'), exclude_pattern="test*"):
+def get_files(path, extensions=('.py', '.pyw'), exclude_pattern=None):
     """Get all files in path ending in extension."""
     fpaths = []
     for dirname, dirnames, filenames in os.walk(path):
@@ -110,9 +110,9 @@ def normalize_string_paths(path, popath):
     pot.save(popath)
 
 
-def scan_path(path, module=None, languages=None):
+def scan_path(path, module=None, languages=None, exclude_pattern=None):
     """Scan path for translations and generate '*.pot' and '*.po' files."""
-    files = get_files(path)
+    files = get_files(path, exclude_pattern=exclude_pattern)
     scan_files(files, path, module=module, languages=languages)
 
 

--- a/gettext_helpers/utils.py
+++ b/gettext_helpers/utils.py
@@ -29,10 +29,10 @@
 from __future__ import print_function, unicode_literals
 
 # Standard library imports
+import fnmatch
 import os
 import os.path as osp
 import subprocess
-import sys
 
 # Third party imports
 import polib
@@ -55,10 +55,13 @@ def _get_locale_path(path):
     return osp.join(path, 'locale')
 
 
-def get_files(path, extensions=('.py', '.pyw')):
+def get_files(path, extensions=('.py', '.pyw'), exclude_pattern="test*"):
     """Get all files in path ending in extension."""
     fpaths = []
-    for dirname, _dirnames, filenames in os.walk(path):
+    for dirname, dirnames, filenames in os.walk(path):
+        dirnames[:] = [
+            d for d in dirnames if not fnmatch.fnmatch(d, exclude_pattern)
+        ]
         for filename in filenames:
             if filename.endswith(extensions):
                 fpaths.append(osp.join(dirname, filename))


### PR DESCRIPTION
Adds a new flag for the CLI (`--exclude-pattern`, `-ep`) to pass a glob definition for directories to exclude from the scan for translations. Its default value is `test*`

Fixes #3 